### PR TITLE
Load sepolicy rules from every available partitions

### DIFF
--- a/native/jni/init/init.hpp
+++ b/native/jni/init/init.hpp
@@ -55,7 +55,7 @@ private:
 protected:
     mmap_data self;
     mmap_data magisk_cfg;
-    std::string custom_rules_dir;
+    std::vector<std::string> custom_rules_dirs;
 
 #if ENABLE_AVD_HACK
     // When this boolean is set, this means we are currently

--- a/native/jni/init/selinux.cpp
+++ b/native/jni/init/selinux.cpp
@@ -15,13 +15,15 @@ void MagiskInit::patch_sepolicy(const char *file) {
     sepol->magisk_rules();
 
     // Custom rules
-    if (!custom_rules_dir.empty()) {
-        if (auto dir = xopen_dir(custom_rules_dir.data())) {
-            for (dirent *entry; (entry = xreaddir(dir.get()));) {
-                auto rule = custom_rules_dir + "/" + entry->d_name + "/sepolicy.rule";
-                if (xaccess(rule.data(), R_OK) == 0) {
-                    LOGD("Loading custom sepolicy patch: [%s]\n", rule.data());
-                    sepol->load_rule_file(rule.data());
+    if (!custom_rules_dirs.empty()) {
+        for (auto &custom_rules_dir : custom_rules_dirs) {
+            if (auto dir = xopen_dir(custom_rules_dir.data())) {
+                for (dirent *entry; (entry = xreaddir(dir.get()));) {
+                    auto rule = custom_rules_dir + "/" + entry->d_name + "/sepolicy.rule";
+                    if (xaccess(rule.data(), R_OK) == 0) {
+                        LOGD("Loading custom sepolicy patch: [%s]\n", rule.data());
+                        sepol->load_rule_file(rule.data());
+                    }
                 }
             }
         }
@@ -45,14 +47,16 @@ void MagiskInit::patch_sepolicy(const char *file) {
 void MagiskInit::hijack_sepolicy() {
     // Read all custom rules into memory
     string rules;
-    if (!custom_rules_dir.empty()) {
-        if (auto dir = xopen_dir(custom_rules_dir.data())) {
-            for (dirent *entry; (entry = xreaddir(dir.get()));) {
-                auto rule_file = custom_rules_dir + "/" + entry->d_name + "/sepolicy.rule";
-                if (xaccess(rule_file.data(), R_OK) == 0) {
-                    LOGD("Load custom sepolicy patch: [%s]\n", rule_file.data());
-                    full_read(rule_file.data(), rules);
-                    rules += '\n';
+    if (!custom_rules_dirs.empty()) {
+        for (auto &custom_rules_dir : custom_rules_dirs) {
+            if (auto dir = xopen_dir(custom_rules_dir.data())) {
+                for (dirent *entry; (entry = xreaddir(dir.get()));) {
+                    auto rule_file = custom_rules_dir + "/" + entry->d_name + "/sepolicy.rule";
+                    if (xaccess(rule_file.data(), R_OK) == 0) {
+                        LOGD("Load custom sepolicy patch: [%s]\n", rule_file.data());
+                        full_read(rule_file.data(), rules);
+                        rules += '\n';
+                    }
                 }
             }
         }


### PR DESCRIPTION
Some devices has /cache or /metadata in their fstab but doesn't actually mount it. We manually find the directory to store sepolicy rules if the directory was given by magiskinit is not available, and magiskinit now will load sepolicy rules from every available partitions to support this case.
Close topjohnwu#4642